### PR TITLE
Update to 1.18.2

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 ext.platform_name = 'fabric'
 ext.loader_version = '0.12.11'
-ext.fabric_version = '0.44.0+1.18'
+ext.fabric_version = '0.53.0+1.18.2'
 
 apply from: '../project_common.gradle'
 apply from: 'project.gradle'

--- a/fabric/project.gradle
+++ b/fabric/project.gradle
@@ -8,15 +8,15 @@ configurations {
 dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
   
-	modIncludeImplementation("grondag:exotic-matter-fabric-mc118:3.0.431:fat")
-  modIncludeImplementation("io.vram:dtklib:1.0.3")
-  modIncludeImplementation("io.vram:modkeys-fabric-mc118:1.0.8")
+	modIncludeImplementation("grondag:exotic-matter-fabric-mc118:3.0.433+:fat")
+	modIncludeImplementation("io.vram:dtklib:1.0.3")
+	modIncludeImplementation("io.vram:modkeys-fabric-mc118:1.0.9+")
 
-  modApi "dev.architectury:architectury-fabric:3.2.60"
-	modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:7.1.357"
-	modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:7.1.357"
-  modCompileOnly "com.terraformersmc:modmenu:3.0.1"
-  modRuntimeOnly "com.terraformersmc:modmenu:3.0.1"
+	modApi "dev.architectury:architectury-fabric:4.4.60"
+	modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:8.1.457"
+	modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:8.1.457"
+	modCompileOnly "com.terraformersmc:modmenu:3.0.1"
+	modRuntimeOnly "com.terraformersmc:modmenu:3.0.1"
 }
 
 sourceSets {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
   "depends": {
   	"fabricloader": ">=0.12.11",
     "fabric": "*",
-    "minecraft": "1.18.1",
+    "minecraft": "1.18.2",
     "java": ">=17",
     "exotic-matter": "*"
   }

--- a/gruntle_common.gradle
+++ b/gruntle_common.gradle
@@ -1,6 +1,6 @@
 ext.mc_tag = 'mc118'
-ext.minecraft_version = '1.18.1'
-ext.release_version = '1.18.1'
+ext.minecraft_version = '1.18.2'
+ext.release_version = '1.18.2'
 
 project.archivesBaseName = project.mod_name + "-" + project.platform_name + "-" + project.mc_tag
 


### PR DESCRIPTION
Requires updated [modkeys](https://github.com/vram-guild/modkeys/pull/1) and [exotic-matter-2](https://github.com/grondag/exotic-matter-2/pull/3)

May need to change the version number dependency for modkeys and exotic-matter after publishing them. For now it uses "+" version dependency.